### PR TITLE
Re-Add `WaitAllStoppedTimeout` using `WaitAllStopped`, but deprecate it

### DIFF
--- a/service.go
+++ b/service.go
@@ -357,7 +357,7 @@ func (c *Container) WaitAllStoppedTimeout(timeout time.Duration) {
 		ctx, cancel = context.WithCancel(context.Background())
 	}
 	defer cancel()
-	return c.WaitAllStopped(ctx)
+	c.WaitAllStopped(ctx)
 }
 
 // ServiceErrors returns all errors occurred in services

--- a/service.go
+++ b/service.go
@@ -346,6 +346,20 @@ func (c *Container) WaitAllStopped(ctx context.Context) {
 	}
 }
 
+// WaitAllStoppedTimeout waits x seconds or until all services are stopped. Services might still run after the call! Call Container.StopAll() to stop them.
+// Deprecated: WaitAllStopped is the preferred method of Waiting for all stopped containers, it can take a context with a deadline/timeout for the same functionality.
+func (c *Container) WaitAllStoppedTimeout(timeout time.Duration) {
+	var ctx context.Context
+	var cancel context.CancelFunc
+	if timeout != 0 {
+		ctx, cancel = context.WithTimeout(context.Background(), timeout)
+	} else {
+		ctx, cancel = context.WithCancel(context.Background())
+	}
+	defer cancel()
+	return c.WaitAllStopped(ctx)
+}
+
 // ServiceErrors returns all errors occurred in services
 func (c *Container) ServiceErrors() map[string]error {
 	errs := map[string]error{}


### PR DESCRIPTION
Re-add `WaitAllStoppedTimeout()` to avoid breaking code using it, but deprecate it to signal that `WaitAllStopped()` should be used instead.

It is re-implemented via `WaitAllStopped()`; we can/will remove `WaitAllStoppedTimeout()` in the next major release