### PR TITLE
Use new repo URL as module URL?

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -2,7 +2,7 @@ package service_test
 
 import (
 	"context"
-	"github.com/niondir/go-service"
+	"github.com/lobaro/go-service"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"

--- a/func_test.go
+++ b/func_test.go
@@ -2,7 +2,7 @@ package service_test
 
 import (
 	"context"
-	"github.com/niondir/go-service"
+	"github.com/lobaro/go-service"
 	"github.com/stretchr/testify/require"
 	"testing"
 	"time"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/niondir/go-service
+module github.com/lobaro/go-service
 
 go 1.23
 

--- a/go.mod
+++ b/go.mod
@@ -2,15 +2,12 @@ module github.com/niondir/go-service
 
 go 1.22
 
-require (
-	github.com/stretchr/testify v1.7.0
-)
+require github.com/stretchr/testify v1.9.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
-	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/niondir/go-service
 
-go 1.22
+go 1.23
 
 require github.com/stretchr/testify v1.9.0
 

--- a/service_test.go
+++ b/service_test.go
@@ -3,7 +3,7 @@ package service_test
 import (
 	"context"
 	"fmt"
-	"github.com/niondir/go-service"
+	"github.com/lobaro/go-service"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"log/slog"


### PR DESCRIPTION
To allow importing it directly from its new location.
As it is a fork of github.com/niondir/go-service, it may be nicer to keep the old path pointing back to its origin...